### PR TITLE
Expose EnableClient to allow client extensions

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,3 +31,6 @@ func (c *Client) Enable(caps []string) ([]string, error) {
 		return res.Capabilities, status.Err()
 	}
 }
+
+// EnableClient is an alias used to compose multiple client extensions.
+type EnableClient = Client


### PR DESCRIPTION
This exposes a new `EnableClient` type alias to allow client extensions